### PR TITLE
feat: open note with publish type

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,9 @@
     "content_scripts": [
         {
             "matches": ["https://hackmd.io/*"],
-            "js": ["contentScript.js"]
+            "js": ["contentScript.js"],
+            "run_at": "document_idle",
+            "all_frames": true
         }
     ],
     "web_accessible_resources": [

--- a/src/pages/Content/types.ts
+++ b/src/pages/Content/types.ts
@@ -1,5 +1,8 @@
 export interface History {
     id: string;
+    shortId: string;
+    userpath: string;
+    teampath: string;
     title: string;
     tags: string[];
 }
@@ -12,6 +15,7 @@ export interface Profile {
         path: string;
         logo: string;
     }[];
+    userpath: string;
 }
 
 export interface Template {
@@ -21,9 +25,18 @@ export interface Template {
 
 export interface SearchResult {
     id: string;
+    shortId: string;
     title: string;
     tags: string[];
     team?: {
         name: string;
+        path: string;
     };
+}
+
+export interface Note {
+    id: string;
+    shortId: string;
+    teampath: string | undefined;
+    userpath: string | undefined;
 }


### PR DESCRIPTION
Usually, you will set publish type as `book` mode if you want to view the page
as book mode by default.

However, you need to right click on the `more` icon and select book mode.

I found that if you use:
Team space: `teampath + shortId`
Personal space: `userpath + shortId`

to open the note then It will show the publish type you set while opening the note.

This will be a handy way switching between notes without interacting with the UI.

Also I add a "inject to all frames setting" to prevent the `kbar` won't show in a book mode
right side which is in a iframe.