### PR TITLE
Support Firefox (109.0 and after)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
-- [About The Project](#about-the-project)
-  - [Features](#features)
-  - [Built With](#built-with)
-- [Installation](#installation)
-- [Usage](#usage)
-  - [Basic](#basic)
-  - [Shortcuts](#shortcuts)
-- [Development](#development)
-- [Roadmap](#roadmap)
-- [Contributing](#contributing)
-- [License](#license)
-- [Contact](#contact)
+-   [Table of Contents](#table-of-contents)
+-   [About The Project](#about-the-project)
+    -   [Features](#features)
+    -   [Built With](#built-with)
+-   [Installation](#installation)
+-   [Usage](#usage)
+    -   [Basic](#basic)
+    -   [Shortcuts](#shortcuts)
+-   [Development](#development)
+-   [Roadmap](#roadmap)
+-   [Contributing](#contributing)
+-   [License](#license)
+-   [Contact](#contact)
 
 ## About The Project
 

--- a/package.json
+++ b/package.json
@@ -11,13 +11,12 @@
     },
     "dependencies": {
         "kbar": "0.1.0-beta.35",
-        "lodash.debounce": "^4.0.8",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react-dom": "^17.0.2",
+        "usehooks-ts": "^2.9.1"
     },
     "devDependencies": {
         "@types/chrome": "^0.0.161",
-        "@types/lodash.debounce": "^4.0.6",
         "@types/react": "^17.0.33",
         "@types/react-dom": "^17.0.10",
         "@typescript-eslint/eslint-plugin": "^5.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,45 +1,56 @@
-lockfileVersion: 5.4
-
-specifiers:
-    "@types/chrome": ^0.0.161
-    "@types/lodash.debounce": ^4.0.6
-    "@types/react": ^17.0.33
-    "@types/react-dom": ^17.0.10
-    "@typescript-eslint/eslint-plugin": ^5.9.1
-    "@typescript-eslint/parser": ^5.9.1
-    archiver: ^5.3.0
-    esbuild: ^0.14.11
-    eslint: ^8.6.0
-    eslint-config-prettier: ^8.3.0
-    kbar: 0.1.0-beta.35
-    lodash.debounce: ^4.0.8
-    prettier: ^2.4.1
-    react: ^17.0.2
-    react-dom: ^17.0.2
-    typescript: ^4.4.4
+lockfileVersion: "6.0"
 
 dependencies:
-    kbar: 0.1.0-beta.35_sfoxds7t5ydpegc3knd667wn6m
-    lodash.debounce: 4.0.8
-    react: 17.0.2
-    react-dom: 17.0.2_react@17.0.2
+    kbar:
+        specifier: 0.1.0-beta.35
+        version: 0.1.0-beta.35(react-dom@17.0.2)(react@17.0.2)
+    react:
+        specifier: ^17.0.2
+        version: 17.0.2
+    react-dom:
+        specifier: ^17.0.2
+        version: 17.0.2(react@17.0.2)
+    usehooks-ts:
+        specifier: ^2.9.1
+        version: 2.9.1(react-dom@17.0.2)(react@17.0.2)
 
 devDependencies:
-    "@types/chrome": 0.0.161
-    "@types/lodash.debounce": 4.0.6
-    "@types/react": 17.0.38
-    "@types/react-dom": 17.0.11
-    "@typescript-eslint/eslint-plugin": 5.9.1_w6zoikzs5yexon6nhzrgweeepm
-    "@typescript-eslint/parser": 5.9.1_z3gsmzc3xu6w45afpmnsgzwvm4
-    archiver: 5.3.0
-    esbuild: 0.14.11
-    eslint: 8.6.0
-    eslint-config-prettier: 8.3.0_eslint@8.6.0
-    prettier: 2.5.1
-    typescript: 4.5.4
+    "@types/chrome":
+        specifier: ^0.0.161
+        version: 0.0.161
+    "@types/react":
+        specifier: ^17.0.33
+        version: 17.0.38
+    "@types/react-dom":
+        specifier: ^17.0.10
+        version: 17.0.11
+    "@typescript-eslint/eslint-plugin":
+        specifier: ^5.9.1
+        version: 5.9.1(@typescript-eslint/parser@5.9.1)(eslint@8.6.0)(typescript@4.5.4)
+    "@typescript-eslint/parser":
+        specifier: ^5.9.1
+        version: 5.9.1(eslint@8.6.0)(typescript@4.5.4)
+    archiver:
+        specifier: ^5.3.0
+        version: 5.3.0
+    esbuild:
+        specifier: ^0.14.11
+        version: 0.14.11
+    eslint:
+        specifier: ^8.6.0
+        version: 8.6.0
+    eslint-config-prettier:
+        specifier: ^8.3.0
+        version: 8.3.0(eslint@8.6.0)
+    prettier:
+        specifier: ^2.4.1
+        version: 2.5.1
+    typescript:
+        specifier: ^4.4.4
+        version: 4.5.4
 
 packages:
-    /@eslint/eslintrc/1.0.5:
+    /@eslint/eslintrc@1.0.5:
         resolution:
             {
                 integrity: sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==,
@@ -59,7 +70,7 @@ packages:
             - supports-color
         dev: true
 
-    /@humanwhocodes/config-array/0.9.2:
+    /@humanwhocodes/config-array@0.9.2:
         resolution:
             {
                 integrity: sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==,
@@ -73,14 +84,14 @@ packages:
             - supports-color
         dev: true
 
-    /@humanwhocodes/object-schema/1.2.1:
+    /@humanwhocodes/object-schema@1.2.1:
         resolution:
             {
                 integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==,
             }
         dev: true
 
-    /@nodelib/fs.scandir/2.1.5:
+    /@nodelib/fs.scandir@2.1.5:
         resolution:
             {
                 integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
@@ -91,7 +102,7 @@ packages:
             run-parallel: 1.2.0
         dev: true
 
-    /@nodelib/fs.stat/2.0.5:
+    /@nodelib/fs.stat@2.0.5:
         resolution:
             {
                 integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
@@ -99,7 +110,7 @@ packages:
         engines: { node: ">= 8" }
         dev: true
 
-    /@nodelib/fs.walk/1.2.8:
+    /@nodelib/fs.walk@1.2.8:
         resolution:
             {
                 integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
@@ -110,14 +121,14 @@ packages:
             fastq: 1.13.0
         dev: true
 
-    /@reach/observe-rect/1.2.0:
+    /@reach/observe-rect@1.2.0:
         resolution:
             {
                 integrity: sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==,
             }
         dev: false
 
-    /@reach/portal/0.16.2_sfoxds7t5ydpegc3knd667wn6m:
+    /@reach/portal@0.16.2(react-dom@17.0.2)(react@17.0.2):
         resolution:
             {
                 integrity: sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==,
@@ -126,14 +137,14 @@ packages:
             react: ^16.8.0 || 17.x
             react-dom: ^16.8.0 || 17.x
         dependencies:
-            "@reach/utils": 0.16.0_sfoxds7t5ydpegc3knd667wn6m
+            "@reach/utils": 0.16.0(react-dom@17.0.2)(react@17.0.2)
             react: 17.0.2
-            react-dom: 17.0.2_react@17.0.2
+            react-dom: 17.0.2(react@17.0.2)
             tiny-warning: 1.0.3
             tslib: 2.3.1
         dev: false
 
-    /@reach/utils/0.16.0_sfoxds7t5ydpegc3knd667wn6m:
+    /@reach/utils@0.16.0(react-dom@17.0.2)(react@17.0.2):
         resolution:
             {
                 integrity: sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==,
@@ -143,12 +154,12 @@ packages:
             react-dom: ^16.8.0 || 17.x
         dependencies:
             react: 17.0.2
-            react-dom: 17.0.2_react@17.0.2
+            react-dom: 17.0.2(react@17.0.2)
             tiny-warning: 1.0.3
             tslib: 2.3.1
         dev: false
 
-    /@types/chrome/0.0.161:
+    /@types/chrome@0.0.161:
         resolution:
             {
                 integrity: sha512-XIzF4QwEN9/fI0QBmV1wVpaJwWGAE+ChvxCTlzbfRDBSk58JD7SBYCqUaMjyMxnG0ehylYWrNR8YOYfHbAdnuA==,
@@ -158,7 +169,7 @@ packages:
             "@types/har-format": 1.2.8
         dev: true
 
-    /@types/filesystem/0.0.32:
+    /@types/filesystem@0.0.32:
         resolution:
             {
                 integrity: sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==,
@@ -167,51 +178,35 @@ packages:
             "@types/filewriter": 0.0.29
         dev: true
 
-    /@types/filewriter/0.0.29:
+    /@types/filewriter@0.0.29:
         resolution:
             {
                 integrity: sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==,
             }
         dev: true
 
-    /@types/har-format/1.2.8:
+    /@types/har-format@1.2.8:
         resolution:
             {
                 integrity: sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==,
             }
         dev: true
 
-    /@types/json-schema/7.0.9:
+    /@types/json-schema@7.0.9:
         resolution:
             {
                 integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==,
             }
         dev: true
 
-    /@types/lodash.debounce/4.0.6:
-        resolution:
-            {
-                integrity: sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==,
-            }
-        dependencies:
-            "@types/lodash": 4.14.178
-        dev: true
-
-    /@types/lodash/4.14.178:
-        resolution:
-            {
-                integrity: sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==,
-            }
-        dev: true
-
-    /@types/prop-types/15.7.4:
+    /@types/prop-types@15.7.4:
         resolution:
             {
                 integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==,
             }
         dev: true
 
-    /@types/react-dom/17.0.11:
+    /@types/react-dom@17.0.11:
         resolution:
             {
                 integrity: sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==,
@@ -220,7 +215,7 @@ packages:
             "@types/react": 17.0.38
         dev: true
 
-    /@types/react/17.0.38:
+    /@types/react@17.0.38:
         resolution:
             {
                 integrity: sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==,
@@ -231,14 +226,14 @@ packages:
             csstype: 3.0.10
         dev: true
 
-    /@types/scheduler/0.16.2:
+    /@types/scheduler@0.16.2:
         resolution:
             {
                 integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==,
             }
         dev: true
 
-    /@typescript-eslint/eslint-plugin/5.9.1_w6zoikzs5yexon6nhzrgweeepm:
+    /@typescript-eslint/eslint-plugin@5.9.1(@typescript-eslint/parser@5.9.1)(eslint@8.6.0)(typescript@4.5.4):
         resolution:
             {
                 integrity: sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==,
@@ -252,23 +247,23 @@ packages:
             typescript:
                 optional: true
         dependencies:
-            "@typescript-eslint/experimental-utils": 5.9.1_z3gsmzc3xu6w45afpmnsgzwvm4
-            "@typescript-eslint/parser": 5.9.1_z3gsmzc3xu6w45afpmnsgzwvm4
+            "@typescript-eslint/experimental-utils": 5.9.1(eslint@8.6.0)(typescript@4.5.4)
+            "@typescript-eslint/parser": 5.9.1(eslint@8.6.0)(typescript@4.5.4)
             "@typescript-eslint/scope-manager": 5.9.1
-            "@typescript-eslint/type-utils": 5.9.1_z3gsmzc3xu6w45afpmnsgzwvm4
+            "@typescript-eslint/type-utils": 5.9.1(eslint@8.6.0)(typescript@4.5.4)
             debug: 4.3.3
             eslint: 8.6.0
             functional-red-black-tree: 1.0.1
             ignore: 5.2.0
             regexpp: 3.2.0
             semver: 7.3.5
-            tsutils: 3.21.0_typescript@4.5.4
+            tsutils: 3.21.0(typescript@4.5.4)
             typescript: 4.5.4
         transitivePeerDependencies:
             - supports-color
         dev: true
 
-    /@typescript-eslint/experimental-utils/5.9.1_z3gsmzc3xu6w45afpmnsgzwvm4:
+    /@typescript-eslint/experimental-utils@5.9.1(eslint@8.6.0)(typescript@4.5.4):
         resolution:
             {
                 integrity: sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==,
@@ -280,16 +275,16 @@ packages:
             "@types/json-schema": 7.0.9
             "@typescript-eslint/scope-manager": 5.9.1
             "@typescript-eslint/types": 5.9.1
-            "@typescript-eslint/typescript-estree": 5.9.1_typescript@4.5.4
+            "@typescript-eslint/typescript-estree": 5.9.1(typescript@4.5.4)
             eslint: 8.6.0
             eslint-scope: 5.1.1
-            eslint-utils: 3.0.0_eslint@8.6.0
+            eslint-utils: 3.0.0(eslint@8.6.0)
         transitivePeerDependencies:
             - supports-color
             - typescript
         dev: true
 
-    /@typescript-eslint/parser/5.9.1_z3gsmzc3xu6w45afpmnsgzwvm4:
+    /@typescript-eslint/parser@5.9.1(eslint@8.6.0)(typescript@4.5.4):
         resolution:
             {
                 integrity: sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==,
@@ -304,7 +299,7 @@ packages:
         dependencies:
             "@typescript-eslint/scope-manager": 5.9.1
             "@typescript-eslint/types": 5.9.1
-            "@typescript-eslint/typescript-estree": 5.9.1_typescript@4.5.4
+            "@typescript-eslint/typescript-estree": 5.9.1(typescript@4.5.4)
             debug: 4.3.3
             eslint: 8.6.0
             typescript: 4.5.4
@@ -312,7 +307,7 @@ packages:
             - supports-color
         dev: true
 
-    /@typescript-eslint/scope-manager/5.9.1:
+    /@typescript-eslint/scope-manager@5.9.1:
         resolution:
             {
                 integrity: sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==,
@@ -323,7 +318,7 @@ packages:
             "@typescript-eslint/visitor-keys": 5.9.1
         dev: true
 
-    /@typescript-eslint/type-utils/5.9.1_z3gsmzc3xu6w45afpmnsgzwvm4:
+    /@typescript-eslint/type-utils@5.9.1(eslint@8.6.0)(typescript@4.5.4):
         resolution:
             {
                 integrity: sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==,
@@ -336,16 +331,16 @@ packages:
             typescript:
                 optional: true
         dependencies:
-            "@typescript-eslint/experimental-utils": 5.9.1_z3gsmzc3xu6w45afpmnsgzwvm4
+            "@typescript-eslint/experimental-utils": 5.9.1(eslint@8.6.0)(typescript@4.5.4)
             debug: 4.3.3
             eslint: 8.6.0
-            tsutils: 3.21.0_typescript@4.5.4
+            tsutils: 3.21.0(typescript@4.5.4)
             typescript: 4.5.4
         transitivePeerDependencies:
             - supports-color
         dev: true
 
-    /@typescript-eslint/types/5.9.1:
+    /@typescript-eslint/types@5.9.1:
         resolution:
             {
                 integrity: sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==,
@@ -353,7 +348,7 @@ packages:
         engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
         dev: true
 
-    /@typescript-eslint/typescript-estree/5.9.1_typescript@4.5.4:
+    /@typescript-eslint/typescript-estree@5.9.1(typescript@4.5.4):
         resolution:
             {
                 integrity: sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==,
@@ -371,13 +366,13 @@ packages:
             globby: 11.1.0
             is-glob: 4.0.3
             semver: 7.3.5
-            tsutils: 3.21.0_typescript@4.5.4
+            tsutils: 3.21.0(typescript@4.5.4)
             typescript: 4.5.4
         transitivePeerDependencies:
             - supports-color
         dev: true
 
-    /@typescript-eslint/visitor-keys/5.9.1:
+    /@typescript-eslint/visitor-keys@5.9.1:
         resolution:
             {
                 integrity: sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==,
@@ -388,7 +383,7 @@ packages:
             eslint-visitor-keys: 3.1.0
         dev: true
 
-    /acorn-jsx/5.3.2_acorn@8.7.0:
+    /acorn-jsx@5.3.2(acorn@8.7.0):
         resolution:
             {
                 integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
@@ -399,7 +394,7 @@ packages:
             acorn: 8.7.0
         dev: true
 
-    /acorn/8.7.0:
+    /acorn@8.7.0:
         resolution:
             {
                 integrity: sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==,
@@ -408,7 +403,7 @@ packages:
         hasBin: true
         dev: true
 
-    /ajv/6.12.6:
+    /ajv@6.12.6:
         resolution:
             {
                 integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
@@ -420,7 +415,7 @@ packages:
             uri-js: 4.4.1
         dev: true
 
-    /ansi-colors/4.1.1:
+    /ansi-colors@4.1.1:
         resolution:
             {
                 integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==,
@@ -428,7 +423,7 @@ packages:
         engines: { node: ">=6" }
         dev: true
 
-    /ansi-regex/5.0.1:
+    /ansi-regex@5.0.1:
         resolution:
             {
                 integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
@@ -436,7 +431,7 @@ packages:
         engines: { node: ">=8" }
         dev: true
 
-    /ansi-styles/4.3.0:
+    /ansi-styles@4.3.0:
         resolution:
             {
                 integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
@@ -446,7 +441,7 @@ packages:
             color-convert: 2.0.1
         dev: true
 
-    /archiver-utils/2.1.0:
+    /archiver-utils@2.1.0:
         resolution:
             {
                 integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==,
@@ -465,7 +460,7 @@ packages:
             readable-stream: 2.3.7
         dev: true
 
-    /archiver/5.3.0:
+    /archiver@5.3.0:
         resolution:
             {
                 integrity: sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==,
@@ -481,14 +476,14 @@ packages:
             zip-stream: 4.1.0
         dev: true
 
-    /argparse/2.0.1:
+    /argparse@2.0.1:
         resolution:
             {
                 integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
             }
         dev: true
 
-    /array-union/2.1.0:
+    /array-union@2.1.0:
         resolution:
             {
                 integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==,
@@ -496,28 +491,28 @@ packages:
         engines: { node: ">=8" }
         dev: true
 
-    /async/3.2.3:
+    /async@3.2.3:
         resolution:
             {
                 integrity: sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==,
             }
         dev: true
 
-    /balanced-match/1.0.2:
+    /balanced-match@1.0.2:
         resolution:
             {
                 integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
             }
         dev: true
 
-    /base64-js/1.5.1:
+    /base64-js@1.5.1:
         resolution:
             {
                 integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
             }
         dev: true
 
-    /bl/4.1.0:
+    /bl@4.1.0:
         resolution:
             {
                 integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
@@ -528,7 +523,7 @@ packages:
             readable-stream: 3.6.0
         dev: true
 
-    /brace-expansion/1.1.11:
+    /brace-expansion@1.1.11:
         resolution:
             {
                 integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==,
@@ -538,7 +533,7 @@ packages:
             concat-map: 0.0.1
         dev: true
 
-    /braces/3.0.2:
+    /braces@3.0.2:
         resolution:
             {
                 integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==,
@@ -548,11 +543,11 @@ packages:
             fill-range: 7.0.1
         dev: true
 
-    /buffer-crc32/0.2.13:
+    /buffer-crc32@0.2.13:
         resolution: { integrity: sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI= }
         dev: true
 
-    /buffer/5.7.1:
+    /buffer@5.7.1:
         resolution:
             {
                 integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
@@ -562,7 +557,7 @@ packages:
             ieee754: 1.2.1
         dev: true
 
-    /callsites/3.1.0:
+    /callsites@3.1.0:
         resolution:
             {
                 integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
@@ -570,7 +565,7 @@ packages:
         engines: { node: ">=6" }
         dev: true
 
-    /chalk/4.1.2:
+    /chalk@4.1.2:
         resolution:
             {
                 integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
@@ -581,7 +576,7 @@ packages:
             supports-color: 7.2.0
         dev: true
 
-    /color-convert/2.0.1:
+    /color-convert@2.0.1:
         resolution:
             {
                 integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
@@ -591,21 +586,21 @@ packages:
             color-name: 1.1.4
         dev: true
 
-    /color-name/1.1.4:
+    /color-name@1.1.4:
         resolution:
             {
                 integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
             }
         dev: true
 
-    /command-score/0.1.2:
+    /command-score@0.1.2:
         resolution:
             {
                 integrity: sha512-VtDvQpIJBvBatnONUsPzXYFVKQQAhuf3XTNOAsdBxCNO/QCtUUd8LSgjn0GVarBkCad6aJCZfXgrjYbl/KRr7w==,
             }
         dev: false
 
-    /compress-commons/4.1.1:
+    /compress-commons@4.1.1:
         resolution:
             {
                 integrity: sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==,
@@ -618,18 +613,18 @@ packages:
             readable-stream: 3.6.0
         dev: true
 
-    /concat-map/0.0.1:
+    /concat-map@0.0.1:
         resolution: { integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= }
         dev: true
 
-    /core-util-is/1.0.3:
+    /core-util-is@1.0.3:
         resolution:
             {
                 integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==,
             }
         dev: true
 
-    /crc-32/1.2.0:
+    /crc-32@1.2.0:
         resolution:
             {
                 integrity: sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==,
@@ -641,7 +636,7 @@ packages:
             printj: 1.1.2
         dev: true
 
-    /crc32-stream/4.0.2:
+    /crc32-stream@4.0.2:
         resolution:
             {
                 integrity: sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==,
@@ -652,7 +647,7 @@ packages:
             readable-stream: 3.6.0
         dev: true
 
-    /cross-spawn/7.0.3:
+    /cross-spawn@7.0.3:
         resolution:
             {
                 integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==,
@@ -664,14 +659,14 @@ packages:
             which: 2.0.2
         dev: true
 
-    /csstype/3.0.10:
+    /csstype@3.0.10:
         resolution:
             {
                 integrity: sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==,
             }
         dev: true
 
-    /debug/4.3.3:
+    /debug@4.3.3:
         resolution:
             {
                 integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==,
@@ -686,14 +681,14 @@ packages:
             ms: 2.1.2
         dev: true
 
-    /deep-is/0.1.4:
+    /deep-is@0.1.4:
         resolution:
             {
                 integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
             }
         dev: true
 
-    /dir-glob/3.0.1:
+    /dir-glob@3.0.1:
         resolution:
             {
                 integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==,
@@ -703,7 +698,7 @@ packages:
             path-type: 4.0.0
         dev: true
 
-    /doctrine/3.0.0:
+    /doctrine@3.0.0:
         resolution:
             {
                 integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==,
@@ -713,7 +708,7 @@ packages:
             esutils: 2.0.3
         dev: true
 
-    /end-of-stream/1.4.4:
+    /end-of-stream@1.4.4:
         resolution:
             {
                 integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==,
@@ -722,7 +717,7 @@ packages:
             once: 1.4.0
         dev: true
 
-    /enquirer/2.3.6:
+    /enquirer@2.3.6:
         resolution:
             {
                 integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==,
@@ -732,7 +727,7 @@ packages:
             ansi-colors: 4.1.1
         dev: true
 
-    /esbuild-android-arm64/0.14.11:
+    /esbuild-android-arm64@0.14.11:
         resolution:
             {
                 integrity: sha512-6iHjgvMnC/SzDH8TefL+/3lgCjYWwAd1LixYfmz/TBPbDQlxcuSkX0yiQgcJB9k+ibZ54yjVXziIwGdlc+6WNw==,
@@ -743,7 +738,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-darwin-64/0.14.11:
+    /esbuild-darwin-64@0.14.11:
         resolution:
             {
                 integrity: sha512-olq84ikh6TiBcrs3FnM4eR5VPPlcJcdW8BnUz/lNoEWYifYQ+Po5DuYV1oz1CTFMw4k6bQIZl8T3yxL+ZT2uvQ==,
@@ -754,7 +749,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-darwin-arm64/0.14.11:
+    /esbuild-darwin-arm64@0.14.11:
         resolution:
             {
                 integrity: sha512-Jj0ieWLREPBYr/TZJrb2GFH8PVzDqiQWavo1pOFFShrcmHWDBDrlDxPzEZ67NF/Un3t6sNNmeI1TUS/fe1xARg==,
@@ -765,7 +760,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-freebsd-64/0.14.11:
+    /esbuild-freebsd-64@0.14.11:
         resolution:
             {
                 integrity: sha512-C5sT3/XIztxxz/zwDjPRHyzj/NJFOnakAanXuyfLDwhwupKPd76/PPHHyJx6Po6NI6PomgVp/zi6GRB8PfrOTA==,
@@ -776,7 +771,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-freebsd-arm64/0.14.11:
+    /esbuild-freebsd-arm64@0.14.11:
         resolution:
             {
                 integrity: sha512-y3Llu4wbs0bk4cwjsdAtVOesXb6JkdfZDLKMt+v1U3tOEPBdSu6w8796VTksJgPfqvpX22JmPLClls0h5p+L9w==,
@@ -787,7 +782,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-linux-32/0.14.11:
+    /esbuild-linux-32@0.14.11:
         resolution:
             {
                 integrity: sha512-Cg3nVsxArjyLke9EuwictFF3Sva+UlDTwHIuIyx8qpxRYAOUTmxr2LzYrhHyTcGOleLGXUXYsnUVwKqnKAgkcg==,
@@ -798,7 +793,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-linux-64/0.14.11:
+    /esbuild-linux-64@0.14.11:
         resolution:
             {
                 integrity: sha512-oeR6dIrrojr8DKVrxtH3xl4eencmjsgI6kPkDCRIIFwv4p+K7ySviM85K66BN01oLjzthpUMvBVfWSJkBLeRbg==,
@@ -809,18 +804,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-linux-arm/0.14.11:
-        resolution:
-            {
-                integrity: sha512-vcwskfD9g0tojux/ZaTJptJQU3a7YgTYsptK1y6LQ/rJmw7U5QJvboNawqM98Ca3ToYEucfCRGbl66OTNtp6KQ==,
-            }
-        cpu: [arm]
-        os: [linux]
-        requiresBuild: true
-        dev: true
-        optional: true
-
-    /esbuild-linux-arm64/0.14.11:
+    /esbuild-linux-arm64@0.14.11:
         resolution:
             {
                 integrity: sha512-+e6ZCgTFQYZlmg2OqLkg1jHLYtkNDksxWDBWNtI4XG4WxuOCUErLqfEt9qWjvzK3XBcCzHImrajkUjO+rRkbMg==,
@@ -831,7 +815,18 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-linux-mips64le/0.14.11:
+    /esbuild-linux-arm@0.14.11:
+        resolution:
+            {
+                integrity: sha512-vcwskfD9g0tojux/ZaTJptJQU3a7YgTYsptK1y6LQ/rJmw7U5QJvboNawqM98Ca3ToYEucfCRGbl66OTNtp6KQ==,
+            }
+        cpu: [arm]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /esbuild-linux-mips64le@0.14.11:
         resolution:
             {
                 integrity: sha512-Rrs99L+p54vepmXIb87xTG6ukrQv+CzrM8eoeR+r/OFL2Rg8RlyEtCeshXJ2+Q66MXZOgPJaokXJZb9snq28bw==,
@@ -842,7 +837,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-linux-ppc64le/0.14.11:
+    /esbuild-linux-ppc64le@0.14.11:
         resolution:
             {
                 integrity: sha512-JyzziGAI0D30Vyzt0HDihp4s1IUtJ3ssV2zx9O/c+U/dhUHVP2TmlYjzCfCr2Q6mwXTeloDcLS4qkyvJtYptdQ==,
@@ -853,7 +848,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-linux-s390x/0.14.11:
+    /esbuild-linux-s390x@0.14.11:
         resolution:
             {
                 integrity: sha512-DoThrkzunZ1nfRGoDN6REwmo8ZZWHd2ztniPVIR5RMw/Il9wiWEYBahb8jnMzQaSOxBsGp0PbyJeVLTUatnlcw==,
@@ -864,7 +859,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-netbsd-64/0.14.11:
+    /esbuild-netbsd-64@0.14.11:
         resolution:
             {
                 integrity: sha512-12luoRQz+6eihKYh1zjrw0CBa2aw3twIiHV/FAfjh2NEBDgJQOY4WCEUEN+Rgon7xmLh4XUxCQjnwrvf8zhACw==,
@@ -875,7 +870,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-openbsd-64/0.14.11:
+    /esbuild-openbsd-64@0.14.11:
         resolution:
             {
                 integrity: sha512-l18TZDjmvwW6cDeR4fmizNoxndyDHamGOOAenwI4SOJbzlJmwfr0jUgjbaXCUuYVOA964siw+Ix+A+bhALWg8Q==,
@@ -886,7 +881,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-sunos-64/0.14.11:
+    /esbuild-sunos-64@0.14.11:
         resolution:
             {
                 integrity: sha512-bmYzDtwASBB8c+0/HVOAiE9diR7+8zLm/i3kEojUH2z0aIs6x/S4KiTuT5/0VKJ4zk69kXel1cNWlHBMkmavQg==,
@@ -897,7 +892,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-windows-32/0.14.11:
+    /esbuild-windows-32@0.14.11:
         resolution:
             {
                 integrity: sha512-J1Ys5hMid8QgdY00OBvIolXgCQn1ARhYtxPnG6ESWNTty3ashtc4+As5nTrsErnv8ZGUcWZe4WzTP/DmEVX1UQ==,
@@ -908,7 +903,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-windows-64/0.14.11:
+    /esbuild-windows-64@0.14.11:
         resolution:
             {
                 integrity: sha512-h9FmMskMuGeN/9G9+LlHPAoiQk9jlKDUn9yA0MpiGzwLa82E7r1b1u+h2a+InprbSnSLxDq/7p5YGtYVO85Mlg==,
@@ -919,7 +914,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild-windows-arm64/0.14.11:
+    /esbuild-windows-arm64@0.14.11:
         resolution:
             {
                 integrity: sha512-dZp7Krv13KpwKklt9/1vBFBMqxEQIO6ri7Azf8C+ob4zOegpJmha2XY9VVWP/OyQ0OWk6cEeIzMJwInRZrzBUQ==,
@@ -930,7 +925,7 @@ packages:
         dev: true
         optional: true
 
-    /esbuild/0.14.11:
+    /esbuild@0.14.11:
         resolution:
             {
                 integrity: sha512-xZvPtVj6yecnDeFb3KjjCM6i7B5TCAQZT77kkW/CpXTMnd6VLnRPKrUB1XHI1pSq6a4Zcy3BGueQ8VljqjDGCg==,
@@ -958,7 +953,7 @@ packages:
             esbuild-windows-arm64: 0.14.11
         dev: true
 
-    /escape-string-regexp/4.0.0:
+    /escape-string-regexp@4.0.0:
         resolution:
             {
                 integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
@@ -966,7 +961,7 @@ packages:
         engines: { node: ">=10" }
         dev: true
 
-    /eslint-config-prettier/8.3.0_eslint@8.6.0:
+    /eslint-config-prettier@8.3.0(eslint@8.6.0):
         resolution:
             {
                 integrity: sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==,
@@ -978,7 +973,7 @@ packages:
             eslint: 8.6.0
         dev: true
 
-    /eslint-scope/5.1.1:
+    /eslint-scope@5.1.1:
         resolution:
             {
                 integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==,
@@ -989,7 +984,7 @@ packages:
             estraverse: 4.3.0
         dev: true
 
-    /eslint-scope/7.1.0:
+    /eslint-scope@7.1.0:
         resolution:
             {
                 integrity: sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==,
@@ -1000,7 +995,7 @@ packages:
             estraverse: 5.3.0
         dev: true
 
-    /eslint-utils/3.0.0_eslint@8.6.0:
+    /eslint-utils@3.0.0(eslint@8.6.0):
         resolution:
             {
                 integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==,
@@ -1013,7 +1008,7 @@ packages:
             eslint-visitor-keys: 2.1.0
         dev: true
 
-    /eslint-visitor-keys/2.1.0:
+    /eslint-visitor-keys@2.1.0:
         resolution:
             {
                 integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==,
@@ -1021,7 +1016,7 @@ packages:
         engines: { node: ">=10" }
         dev: true
 
-    /eslint-visitor-keys/3.1.0:
+    /eslint-visitor-keys@3.1.0:
         resolution:
             {
                 integrity: sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==,
@@ -1029,7 +1024,7 @@ packages:
         engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
         dev: true
 
-    /eslint/8.6.0:
+    /eslint@8.6.0:
         resolution:
             {
                 integrity: sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==,
@@ -1047,7 +1042,7 @@ packages:
             enquirer: 2.3.6
             escape-string-regexp: 4.0.0
             eslint-scope: 7.1.0
-            eslint-utils: 3.0.0_eslint@8.6.0
+            eslint-utils: 3.0.0(eslint@8.6.0)
             eslint-visitor-keys: 3.1.0
             espree: 9.3.0
             esquery: 1.4.0
@@ -1079,7 +1074,7 @@ packages:
             - supports-color
         dev: true
 
-    /espree/9.3.0:
+    /espree@9.3.0:
         resolution:
             {
                 integrity: sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==,
@@ -1087,11 +1082,11 @@ packages:
         engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
         dependencies:
             acorn: 8.7.0
-            acorn-jsx: 5.3.2_acorn@8.7.0
+            acorn-jsx: 5.3.2(acorn@8.7.0)
             eslint-visitor-keys: 3.1.0
         dev: true
 
-    /esquery/1.4.0:
+    /esquery@1.4.0:
         resolution:
             {
                 integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==,
@@ -1101,7 +1096,7 @@ packages:
             estraverse: 5.3.0
         dev: true
 
-    /esrecurse/4.3.0:
+    /esrecurse@4.3.0:
         resolution:
             {
                 integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
@@ -1111,7 +1106,7 @@ packages:
             estraverse: 5.3.0
         dev: true
 
-    /estraverse/4.3.0:
+    /estraverse@4.3.0:
         resolution:
             {
                 integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==,
@@ -1119,7 +1114,7 @@ packages:
         engines: { node: ">=4.0" }
         dev: true
 
-    /estraverse/5.3.0:
+    /estraverse@5.3.0:
         resolution:
             {
                 integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
@@ -1127,7 +1122,7 @@ packages:
         engines: { node: ">=4.0" }
         dev: true
 
-    /esutils/2.0.3:
+    /esutils@2.0.3:
         resolution:
             {
                 integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
@@ -1135,7 +1130,7 @@ packages:
         engines: { node: ">=0.10.0" }
         dev: true
 
-    /exit-on-epipe/1.0.1:
+    /exit-on-epipe@1.0.1:
         resolution:
             {
                 integrity: sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==,
@@ -1143,21 +1138,21 @@ packages:
         engines: { node: ">=0.8" }
         dev: true
 
-    /fast-deep-equal/3.1.3:
+    /fast-deep-equal@3.1.3:
         resolution:
             {
                 integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
             }
         dev: true
 
-    /fast-equals/2.0.4:
+    /fast-equals@2.0.4:
         resolution:
             {
                 integrity: sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w==,
             }
         dev: false
 
-    /fast-glob/3.2.10:
+    /fast-glob@3.2.10:
         resolution:
             {
                 integrity: sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==,
@@ -1171,18 +1166,18 @@ packages:
             micromatch: 4.0.4
         dev: true
 
-    /fast-json-stable-stringify/2.1.0:
+    /fast-json-stable-stringify@2.1.0:
         resolution:
             {
                 integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
             }
         dev: true
 
-    /fast-levenshtein/2.0.6:
+    /fast-levenshtein@2.0.6:
         resolution: { integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc= }
         dev: true
 
-    /fastq/1.13.0:
+    /fastq@1.13.0:
         resolution:
             {
                 integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==,
@@ -1191,7 +1186,7 @@ packages:
             reusify: 1.0.4
         dev: true
 
-    /file-entry-cache/6.0.1:
+    /file-entry-cache@6.0.1:
         resolution:
             {
                 integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==,
@@ -1201,7 +1196,7 @@ packages:
             flat-cache: 3.0.4
         dev: true
 
-    /fill-range/7.0.1:
+    /fill-range@7.0.1:
         resolution:
             {
                 integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==,
@@ -1211,7 +1206,7 @@ packages:
             to-regex-range: 5.0.1
         dev: true
 
-    /flat-cache/3.0.4:
+    /flat-cache@3.0.4:
         resolution:
             {
                 integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==,
@@ -1222,29 +1217,29 @@ packages:
             rimraf: 3.0.2
         dev: true
 
-    /flatted/3.2.4:
+    /flatted@3.2.4:
         resolution:
             {
                 integrity: sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==,
             }
         dev: true
 
-    /fs-constants/1.0.0:
+    /fs-constants@1.0.0:
         resolution:
             {
                 integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==,
             }
         dev: true
 
-    /fs.realpath/1.0.0:
+    /fs.realpath@1.0.0:
         resolution: { integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8= }
         dev: true
 
-    /functional-red-black-tree/1.0.1:
+    /functional-red-black-tree@1.0.1:
         resolution: { integrity: sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc= }
         dev: true
 
-    /glob-parent/5.1.2:
+    /glob-parent@5.1.2:
         resolution:
             {
                 integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
@@ -1254,7 +1249,7 @@ packages:
             is-glob: 4.0.3
         dev: true
 
-    /glob-parent/6.0.2:
+    /glob-parent@6.0.2:
         resolution:
             {
                 integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
@@ -1264,7 +1259,7 @@ packages:
             is-glob: 4.0.3
         dev: true
 
-    /glob/7.2.0:
+    /glob@7.2.0:
         resolution:
             {
                 integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==,
@@ -1278,7 +1273,7 @@ packages:
             path-is-absolute: 1.0.1
         dev: true
 
-    /globals/13.12.0:
+    /globals@13.12.0:
         resolution:
             {
                 integrity: sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==,
@@ -1288,7 +1283,7 @@ packages:
             type-fest: 0.20.2
         dev: true
 
-    /globby/11.1.0:
+    /globby@11.1.0:
         resolution:
             {
                 integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==,
@@ -1303,14 +1298,14 @@ packages:
             slash: 3.0.0
         dev: true
 
-    /graceful-fs/4.2.9:
+    /graceful-fs@4.2.9:
         resolution:
             {
                 integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==,
             }
         dev: true
 
-    /has-flag/4.0.0:
+    /has-flag@4.0.0:
         resolution:
             {
                 integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
@@ -1318,14 +1313,14 @@ packages:
         engines: { node: ">=8" }
         dev: true
 
-    /ieee754/1.2.1:
+    /ieee754@1.2.1:
         resolution:
             {
                 integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
             }
         dev: true
 
-    /ignore/4.0.6:
+    /ignore@4.0.6:
         resolution:
             {
                 integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==,
@@ -1333,7 +1328,7 @@ packages:
         engines: { node: ">= 4" }
         dev: true
 
-    /ignore/5.2.0:
+    /ignore@5.2.0:
         resolution:
             {
                 integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==,
@@ -1341,7 +1336,7 @@ packages:
         engines: { node: ">= 4" }
         dev: true
 
-    /import-fresh/3.3.0:
+    /import-fresh@3.3.0:
         resolution:
             {
                 integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==,
@@ -1352,31 +1347,31 @@ packages:
             resolve-from: 4.0.0
         dev: true
 
-    /imurmurhash/0.1.4:
+    /imurmurhash@0.1.4:
         resolution: { integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o= }
         engines: { node: ">=0.8.19" }
         dev: true
 
-    /inflight/1.0.6:
+    /inflight@1.0.6:
         resolution: { integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk= }
         dependencies:
             once: 1.4.0
             wrappy: 1.0.2
         dev: true
 
-    /inherits/2.0.4:
+    /inherits@2.0.4:
         resolution:
             {
                 integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
             }
         dev: true
 
-    /is-extglob/2.1.1:
+    /is-extglob@2.1.1:
         resolution: { integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI= }
         engines: { node: ">=0.10.0" }
         dev: true
 
-    /is-glob/4.0.3:
+    /is-glob@4.0.3:
         resolution:
             {
                 integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
@@ -1386,7 +1381,7 @@ packages:
             is-extglob: 2.1.1
         dev: true
 
-    /is-number/7.0.0:
+    /is-number@7.0.0:
         resolution:
             {
                 integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
@@ -1394,22 +1389,22 @@ packages:
         engines: { node: ">=0.12.0" }
         dev: true
 
-    /isarray/1.0.0:
+    /isarray@1.0.0:
         resolution: { integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE= }
         dev: true
 
-    /isexe/2.0.0:
+    /isexe@2.0.0:
         resolution: { integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA= }
         dev: true
 
-    /js-tokens/4.0.0:
+    /js-tokens@4.0.0:
         resolution:
             {
                 integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
             }
         dev: false
 
-    /js-yaml/4.1.0:
+    /js-yaml@4.1.0:
         resolution:
             {
                 integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==,
@@ -1419,18 +1414,18 @@ packages:
             argparse: 2.0.1
         dev: true
 
-    /json-schema-traverse/0.4.1:
+    /json-schema-traverse@0.4.1:
         resolution:
             {
                 integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
             }
         dev: true
 
-    /json-stable-stringify-without-jsonify/1.0.1:
+    /json-stable-stringify-without-jsonify@1.0.1:
         resolution: { integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE= }
         dev: true
 
-    /kbar/0.1.0-beta.35_sfoxds7t5ydpegc3knd667wn6m:
+    /kbar@0.1.0-beta.35(react-dom@17.0.2)(react@17.0.2):
         resolution:
             {
                 integrity: sha512-lXA/AFfmeTBIC0+6wsqHPpU1ULI4MMgzX9cRKkpHh9BVij5t1EAJOFTLzQQBr/4jVzSYNwRogRHHU4oQAlAduQ==,
@@ -1439,16 +1434,16 @@ packages:
             react: ^16.0.0 || ^17.0.0
             react-dom: ^16.0.0 || ^17.0.0
         dependencies:
-            "@reach/portal": 0.16.2_sfoxds7t5ydpegc3knd667wn6m
+            "@reach/portal": 0.16.2(react-dom@17.0.2)(react@17.0.2)
             command-score: 0.1.2
             fast-equals: 2.0.4
             react: 17.0.2
-            react-dom: 17.0.2_react@17.0.2
-            react-virtual: 2.10.0_react@17.0.2
+            react-dom: 17.0.2(react@17.0.2)
+            react-virtual: 2.10.0(react@17.0.2)
             tiny-invariant: 1.2.0
         dev: false
 
-    /lazystream/1.0.1:
+    /lazystream@1.0.1:
         resolution:
             {
                 integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==,
@@ -1458,7 +1453,7 @@ packages:
             readable-stream: 2.3.7
         dev: true
 
-    /levn/0.4.1:
+    /levn@0.4.1:
         resolution:
             {
                 integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
@@ -1469,38 +1464,34 @@ packages:
             type-check: 0.4.0
         dev: true
 
-    /lodash.debounce/4.0.8:
-        resolution: { integrity: sha1-gteb/zCmfEAF/9XiUVMArZyk168= }
-        dev: false
-
-    /lodash.defaults/4.2.0:
+    /lodash.defaults@4.2.0:
         resolution: { integrity: sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw= }
         dev: true
 
-    /lodash.difference/4.5.0:
+    /lodash.difference@4.5.0:
         resolution: { integrity: sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw= }
         dev: true
 
-    /lodash.flatten/4.4.0:
+    /lodash.flatten@4.4.0:
         resolution: { integrity: sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8= }
         dev: true
 
-    /lodash.isplainobject/4.0.6:
+    /lodash.isplainobject@4.0.6:
         resolution: { integrity: sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs= }
         dev: true
 
-    /lodash.merge/4.6.2:
+    /lodash.merge@4.6.2:
         resolution:
             {
                 integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
             }
         dev: true
 
-    /lodash.union/4.6.0:
+    /lodash.union@4.6.0:
         resolution: { integrity: sha1-SLtQiECfFvGCFmZkHETdGqrjzYg= }
         dev: true
 
-    /loose-envify/1.4.0:
+    /loose-envify@1.4.0:
         resolution:
             {
                 integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
@@ -1510,7 +1501,7 @@ packages:
             js-tokens: 4.0.0
         dev: false
 
-    /lru-cache/6.0.0:
+    /lru-cache@6.0.0:
         resolution:
             {
                 integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==,
@@ -1520,7 +1511,7 @@ packages:
             yallist: 4.0.0
         dev: true
 
-    /merge2/1.4.1:
+    /merge2@1.4.1:
         resolution:
             {
                 integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
@@ -1528,7 +1519,7 @@ packages:
         engines: { node: ">= 8" }
         dev: true
 
-    /micromatch/4.0.4:
+    /micromatch@4.0.4:
         resolution:
             {
                 integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==,
@@ -1539,7 +1530,7 @@ packages:
             picomatch: 2.3.1
         dev: true
 
-    /minimatch/3.0.4:
+    /minimatch@3.0.4:
         resolution:
             {
                 integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==,
@@ -1548,18 +1539,18 @@ packages:
             brace-expansion: 1.1.11
         dev: true
 
-    /ms/2.1.2:
+    /ms@2.1.2:
         resolution:
             {
                 integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==,
             }
         dev: true
 
-    /natural-compare/1.4.0:
+    /natural-compare@1.4.0:
         resolution: { integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc= }
         dev: true
 
-    /normalize-path/3.0.0:
+    /normalize-path@3.0.0:
         resolution:
             {
                 integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
@@ -1567,18 +1558,18 @@ packages:
         engines: { node: ">=0.10.0" }
         dev: true
 
-    /object-assign/4.1.1:
+    /object-assign@4.1.1:
         resolution: { integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM= }
         engines: { node: ">=0.10.0" }
         dev: false
 
-    /once/1.4.0:
+    /once@1.4.0:
         resolution: { integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E= }
         dependencies:
             wrappy: 1.0.2
         dev: true
 
-    /optionator/0.9.1:
+    /optionator@0.9.1:
         resolution:
             {
                 integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==,
@@ -1593,7 +1584,7 @@ packages:
             word-wrap: 1.2.3
         dev: true
 
-    /parent-module/1.0.1:
+    /parent-module@1.0.1:
         resolution:
             {
                 integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
@@ -1603,12 +1594,12 @@ packages:
             callsites: 3.1.0
         dev: true
 
-    /path-is-absolute/1.0.1:
+    /path-is-absolute@1.0.1:
         resolution: { integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18= }
         engines: { node: ">=0.10.0" }
         dev: true
 
-    /path-key/3.1.1:
+    /path-key@3.1.1:
         resolution:
             {
                 integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
@@ -1616,7 +1607,7 @@ packages:
         engines: { node: ">=8" }
         dev: true
 
-    /path-type/4.0.0:
+    /path-type@4.0.0:
         resolution:
             {
                 integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
@@ -1624,7 +1615,7 @@ packages:
         engines: { node: ">=8" }
         dev: true
 
-    /picomatch/2.3.1:
+    /picomatch@2.3.1:
         resolution:
             {
                 integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
@@ -1632,7 +1623,7 @@ packages:
         engines: { node: ">=8.6" }
         dev: true
 
-    /prelude-ls/1.2.1:
+    /prelude-ls@1.2.1:
         resolution:
             {
                 integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
@@ -1640,7 +1631,7 @@ packages:
         engines: { node: ">= 0.8.0" }
         dev: true
 
-    /prettier/2.5.1:
+    /prettier@2.5.1:
         resolution:
             {
                 integrity: sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==,
@@ -1649,7 +1640,7 @@ packages:
         hasBin: true
         dev: true
 
-    /printj/1.1.2:
+    /printj@1.1.2:
         resolution:
             {
                 integrity: sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==,
@@ -1658,14 +1649,14 @@ packages:
         hasBin: true
         dev: true
 
-    /process-nextick-args/2.0.1:
+    /process-nextick-args@2.0.1:
         resolution:
             {
                 integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==,
             }
         dev: true
 
-    /progress/2.0.3:
+    /progress@2.0.3:
         resolution:
             {
                 integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==,
@@ -1673,7 +1664,7 @@ packages:
         engines: { node: ">=0.4.0" }
         dev: true
 
-    /punycode/2.1.1:
+    /punycode@2.1.1:
         resolution:
             {
                 integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==,
@@ -1681,14 +1672,14 @@ packages:
         engines: { node: ">=6" }
         dev: true
 
-    /queue-microtask/1.2.3:
+    /queue-microtask@1.2.3:
         resolution:
             {
                 integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
             }
         dev: true
 
-    /react-dom/17.0.2_react@17.0.2:
+    /react-dom@17.0.2(react@17.0.2):
         resolution:
             {
                 integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==,
@@ -1702,7 +1693,7 @@ packages:
             scheduler: 0.20.2
         dev: false
 
-    /react-virtual/2.10.0_react@17.0.2:
+    /react-virtual@2.10.0(react@17.0.2):
         resolution:
             {
                 integrity: sha512-Mgy//1Ty0YMcELTooFq5mMrEb4dLRzS9PbPrgDbpdgGRgG9RuQrXBxgPCm1vNBonoiNZjbsGSEPLuJ7MuHLvLg==,
@@ -1714,7 +1705,7 @@ packages:
             react: 17.0.2
         dev: false
 
-    /react/17.0.2:
+    /react@17.0.2:
         resolution:
             {
                 integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==,
@@ -1725,7 +1716,7 @@ packages:
             object-assign: 4.1.1
         dev: false
 
-    /readable-stream/2.3.7:
+    /readable-stream@2.3.7:
         resolution:
             {
                 integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==,
@@ -1740,7 +1731,7 @@ packages:
             util-deprecate: 1.0.2
         dev: true
 
-    /readable-stream/3.6.0:
+    /readable-stream@3.6.0:
         resolution:
             {
                 integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==,
@@ -1752,7 +1743,7 @@ packages:
             util-deprecate: 1.0.2
         dev: true
 
-    /readdir-glob/1.1.1:
+    /readdir-glob@1.1.1:
         resolution:
             {
                 integrity: sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==,
@@ -1761,7 +1752,7 @@ packages:
             minimatch: 3.0.4
         dev: true
 
-    /regexpp/3.2.0:
+    /regexpp@3.2.0:
         resolution:
             {
                 integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==,
@@ -1769,7 +1760,7 @@ packages:
         engines: { node: ">=8" }
         dev: true
 
-    /resolve-from/4.0.0:
+    /resolve-from@4.0.0:
         resolution:
             {
                 integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
@@ -1777,7 +1768,7 @@ packages:
         engines: { node: ">=4" }
         dev: true
 
-    /reusify/1.0.4:
+    /reusify@1.0.4:
         resolution:
             {
                 integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==,
@@ -1785,7 +1776,7 @@ packages:
         engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
         dev: true
 
-    /rimraf/3.0.2:
+    /rimraf@3.0.2:
         resolution:
             {
                 integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==,
@@ -1795,7 +1786,7 @@ packages:
             glob: 7.2.0
         dev: true
 
-    /run-parallel/1.2.0:
+    /run-parallel@1.2.0:
         resolution:
             {
                 integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
@@ -1804,21 +1795,21 @@ packages:
             queue-microtask: 1.2.3
         dev: true
 
-    /safe-buffer/5.1.2:
+    /safe-buffer@5.1.2:
         resolution:
             {
                 integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==,
             }
         dev: true
 
-    /safe-buffer/5.2.1:
+    /safe-buffer@5.2.1:
         resolution:
             {
                 integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
             }
         dev: true
 
-    /scheduler/0.20.2:
+    /scheduler@0.20.2:
         resolution:
             {
                 integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==,
@@ -1828,7 +1819,7 @@ packages:
             object-assign: 4.1.1
         dev: false
 
-    /semver/7.3.5:
+    /semver@7.3.5:
         resolution:
             {
                 integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==,
@@ -1839,7 +1830,7 @@ packages:
             lru-cache: 6.0.0
         dev: true
 
-    /shebang-command/2.0.0:
+    /shebang-command@2.0.0:
         resolution:
             {
                 integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
@@ -1849,7 +1840,7 @@ packages:
             shebang-regex: 3.0.0
         dev: true
 
-    /shebang-regex/3.0.0:
+    /shebang-regex@3.0.0:
         resolution:
             {
                 integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
@@ -1857,7 +1848,7 @@ packages:
         engines: { node: ">=8" }
         dev: true
 
-    /slash/3.0.0:
+    /slash@3.0.0:
         resolution:
             {
                 integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
@@ -1865,7 +1856,7 @@ packages:
         engines: { node: ">=8" }
         dev: true
 
-    /string_decoder/1.1.1:
+    /string_decoder@1.1.1:
         resolution:
             {
                 integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==,
@@ -1874,7 +1865,7 @@ packages:
             safe-buffer: 5.1.2
         dev: true
 
-    /string_decoder/1.3.0:
+    /string_decoder@1.3.0:
         resolution:
             {
                 integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
@@ -1883,7 +1874,7 @@ packages:
             safe-buffer: 5.2.1
         dev: true
 
-    /strip-ansi/6.0.1:
+    /strip-ansi@6.0.1:
         resolution:
             {
                 integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
@@ -1893,7 +1884,7 @@ packages:
             ansi-regex: 5.0.1
         dev: true
 
-    /strip-json-comments/3.1.1:
+    /strip-json-comments@3.1.1:
         resolution:
             {
                 integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
@@ -1901,7 +1892,7 @@ packages:
         engines: { node: ">=8" }
         dev: true
 
-    /supports-color/7.2.0:
+    /supports-color@7.2.0:
         resolution:
             {
                 integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
@@ -1911,7 +1902,7 @@ packages:
             has-flag: 4.0.0
         dev: true
 
-    /tar-stream/2.2.0:
+    /tar-stream@2.2.0:
         resolution:
             {
                 integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==,
@@ -1925,25 +1916,25 @@ packages:
             readable-stream: 3.6.0
         dev: true
 
-    /text-table/0.2.0:
+    /text-table@0.2.0:
         resolution: { integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ= }
         dev: true
 
-    /tiny-invariant/1.2.0:
+    /tiny-invariant@1.2.0:
         resolution:
             {
                 integrity: sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==,
             }
         dev: false
 
-    /tiny-warning/1.0.3:
+    /tiny-warning@1.0.3:
         resolution:
             {
                 integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==,
             }
         dev: false
 
-    /to-regex-range/5.0.1:
+    /to-regex-range@5.0.1:
         resolution:
             {
                 integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
@@ -1953,21 +1944,21 @@ packages:
             is-number: 7.0.0
         dev: true
 
-    /tslib/1.14.1:
+    /tslib@1.14.1:
         resolution:
             {
                 integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==,
             }
         dev: true
 
-    /tslib/2.3.1:
+    /tslib@2.3.1:
         resolution:
             {
                 integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==,
             }
         dev: false
 
-    /tsutils/3.21.0_typescript@4.5.4:
+    /tsutils@3.21.0(typescript@4.5.4):
         resolution:
             {
                 integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==,
@@ -1980,7 +1971,7 @@ packages:
             typescript: 4.5.4
         dev: true
 
-    /type-check/0.4.0:
+    /type-check@0.4.0:
         resolution:
             {
                 integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
@@ -1990,7 +1981,7 @@ packages:
             prelude-ls: 1.2.1
         dev: true
 
-    /type-fest/0.20.2:
+    /type-fest@0.20.2:
         resolution:
             {
                 integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==,
@@ -1998,7 +1989,7 @@ packages:
         engines: { node: ">=10" }
         dev: true
 
-    /typescript/4.5.4:
+    /typescript@4.5.4:
         resolution:
             {
                 integrity: sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==,
@@ -2007,7 +1998,7 @@ packages:
         hasBin: true
         dev: true
 
-    /uri-js/4.4.1:
+    /uri-js@4.4.1:
         resolution:
             {
                 integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
@@ -2016,18 +2007,32 @@ packages:
             punycode: 2.1.1
         dev: true
 
-    /util-deprecate/1.0.2:
+    /usehooks-ts@2.9.1(react-dom@17.0.2)(react@17.0.2):
+        resolution:
+            {
+                integrity: sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==,
+            }
+        engines: { node: ">=16.15.0", npm: ">=8" }
+        peerDependencies:
+            react: ^16.8.0  || ^17.0.0 || ^18.0.0
+            react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+        dependencies:
+            react: 17.0.2
+            react-dom: 17.0.2(react@17.0.2)
+        dev: false
+
+    /util-deprecate@1.0.2:
         resolution: { integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8= }
         dev: true
 
-    /v8-compile-cache/2.3.0:
+    /v8-compile-cache@2.3.0:
         resolution:
             {
                 integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==,
             }
         dev: true
 
-    /which/2.0.2:
+    /which@2.0.2:
         resolution:
             {
                 integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
@@ -2038,7 +2043,7 @@ packages:
             isexe: 2.0.0
         dev: true
 
-    /word-wrap/1.2.3:
+    /word-wrap@1.2.3:
         resolution:
             {
                 integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==,
@@ -2046,18 +2051,18 @@ packages:
         engines: { node: ">=0.10.0" }
         dev: true
 
-    /wrappy/1.0.2:
+    /wrappy@1.0.2:
         resolution: { integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= }
         dev: true
 
-    /yallist/4.0.0:
+    /yallist@4.0.0:
         resolution:
             {
                 integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==,
             }
         dev: true
 
-    /zip-stream/4.1.0:
+    /zip-stream@4.1.0:
         resolution:
             {
                 integrity: sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,33 +6,22 @@
         "default_popup": "popup.html",
         "default_icon": "icon-34.png"
     },
-    "permissions": [
-        "storage"
-    ],
+    "permissions": ["storage"],
     "icons": {
         "128": "icon-128.png"
     },
     "content_scripts": [
         {
-            "matches": [
-                "https://hackmd.io/*"
-            ],
-            "js": [
-                "contentScript.js"
-            ],
+            "matches": ["https://hackmd.io/*"],
+            "js": ["contentScript.js"],
             "run_at": "document_idle",
             "all_frames": true
         }
     ],
     "web_accessible_resources": [
         {
-            "resources": [
-                "icon-128.png",
-                "icon-34.png"
-            ],
-            "matches": [
-                "<all_urls>"
-            ]
+            "resources": ["icon-128.png", "icon-34.png"],
+            "matches": ["<all_urls>"]
         }
     ],
     "browser_specific_settings": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,22 +6,38 @@
         "default_popup": "popup.html",
         "default_icon": "icon-34.png"
     },
-    "permissions": ["storage"],
+    "permissions": [
+        "storage"
+    ],
     "icons": {
         "128": "icon-128.png"
     },
     "content_scripts": [
         {
-            "matches": ["https://hackmd.io/*"],
-            "js": ["contentScript.js"],
+            "matches": [
+                "https://hackmd.io/*"
+            ],
+            "js": [
+                "contentScript.js"
+            ],
             "run_at": "document_idle",
             "all_frames": true
         }
     ],
     "web_accessible_resources": [
         {
-            "resources": ["icon-128.png", "icon-34.png"],
-            "matches": []
+            "resources": [
+                "icon-128.png",
+                "icon-34.png"
+            ],
+            "matches": [
+                "<all_urls>"
+            ]
         }
-    ]
+    ],
+    "browser_specific_settings": {
+        "gecko": {
+            "id": "ap9940506@gmail.com"
+        }
+    }
 }

--- a/src/pages/Content/useActions.tsx
+++ b/src/pages/Content/useActions.tsx
@@ -1,6 +1,6 @@
 import type { Action } from "kbar";
 import { useState, useMemo, useEffect, useCallback } from "react";
-import debounce from "lodash.debounce";
+import { useDebounce } from "usehooks-ts";
 import { defaultActions, emptyNoteAction } from "./defaultActions";
 import { fetchRecentNotes, fetchTeams, fetchTemplaces, searchNotes } from "./fetchActions";
 
@@ -9,6 +9,7 @@ function useActions(query: string) {
     const [teamActions, setTeamActions] = useState<Action[]>([]);
     const [templateActions, setTemplateActions] = useState<Action[]>([]);
     const [searchedNoteActions, setSearchedNoteActions] = useState<Action[]>([]);
+    const debouncedQuery = useDebounce<string>(query, 500);
 
     /**
      * Putting defaultActions here again is a workaround to order the actions,
@@ -45,15 +46,12 @@ function useActions(query: string) {
             .catch(() => setTeamActions([]));
     }, []);
 
-    const collectSearchedNoteActions = useCallback(
-        debounce((query) => {
-            searchNotes(query)
-                .then(setSearchedNoteActions)
-                .catch(console.error)
-                .catch(() => setSearchedNoteActions([]));
-        }, 500),
-        [],
-    );
+    const collectSearchedNoteActions = useCallback((query) => {
+        searchNotes(query)
+            .then(setSearchedNoteActions)
+            .catch(console.error)
+            .catch(() => setSearchedNoteActions([]));
+    }, []);
 
     useEffect(() => {
         collectTeamActions();
@@ -65,8 +63,8 @@ function useActions(query: string) {
     }, [window.location.pathname]);
 
     useEffect(() => {
-        collectSearchedNoteActions(query);
-    }, [query]);
+        collectSearchedNoteActions(debouncedQuery);
+    }, [debouncedQuery]);
 
     return { actions };
 }


### PR DESCRIPTION
closes #2 
closes #9 

on January 17, 2023, [new release](https://www.mozilla.org/en-US/firefox/109.0/releasenotes/) supports manifest version 3, so I change the manifest.json a bit to meet the requirements of Firefox add-on.

However, the kbar seems not working in Firefox debug environment, I'm still trying to figure out why.